### PR TITLE
Add development Docker setup with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Logs and temporary analysis outputs
+logs/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+ENV/
+env.bak/
+venv/
+
+# Pytest cache
+.pytest_cache/
+
+# Coverage reports
+htmlcov/
+.coverage*
+
+# Editor settings
+.vscode/
+.idea/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.6
+
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN python -m pip install --upgrade pip setuptools wheel
+
+RUN if [ -f "requirements.txt" ]; then pip install -r requirements.txt; fi
+RUN if [ -f "requirements-dev.txt" ]; then pip install -r requirements-dev.txt; fi
+
+ENV DJANGO_LOG_DIR=/app/logs
+
+RUN mkdir -p "$DJANGO_LOG_DIR"
+
+EXPOSE 8000
+
+CMD ["bash", "scripts/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .:/app
       - ./logs:/app/logs
     ports:
-      - "8000:8000"
+      - "18001:8000"
     env_file:
       - env/.env.development
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash scripts/entrypoint.sh
+    volumes:
+      - .:/app
+      - ./logs:/app/logs
+    ports:
+      - "8000:8000"
+    env_file:
+      - env/.env.development
+    environment:
+      DJANGO_LOG_DIR: /app/logs
+      DATABASE_URL: postgres://app:app@db:5432/app
+    depends_on:
+      db:
+        condition: service_healthy
+
+  devtools:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash scripts/run_checks.sh
+    volumes:
+      - .:/app
+      - ./logs:/app/logs
+    env_file:
+      - env/.env.development
+    environment:
+      DJANGO_LOG_DIR: /app/logs
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/env/.env.development
+++ b/env/.env.development
@@ -1,0 +1,6 @@
+# Django アプリ開発用サンプル環境変数
+DJANGO_ENV=development
+SECRET_KEY=change-me
+DATABASE_URL=postgres://app:app@db:5432/app
+ALLOWED_HOSTS=127.0.0.1,localhost
+LOG_LEVEL=INFO

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LOG_DIR="${DJANGO_LOG_DIR:-/app/logs}"
+mkdir -p "${LOG_DIR}"
+
+if command -v python >/dev/null 2>&1 && [ -f manage.py ]; then
+  python manage.py migrate --noinput 2>&1 | tee "${LOG_DIR}/migrate.log"
+  exec python manage.py runserver 0.0.0.0:8000
+else
+  echo "manage.py が見つからないため、Django サーバーは起動しません。" | tee "${LOG_DIR}/entrypoint.log"
+  exec tail -f /dev/null
+fi

--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LOG_DIR="${DJANGO_LOG_DIR:-/app/logs}"
+mkdir -p "${LOG_DIR}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+STATUS=0
+
+run_tool() {
+  local tool="$1"
+  local log_name="$2"
+  shift 2
+
+  local log_file="${LOG_DIR}/${log_name}-${TIMESTAMP}.log"
+
+  if command -v "${tool}" >/dev/null 2>&1; then
+    echo "Running ${tool}..."
+    set +e
+    "${tool}" "$@" | tee "${log_file}"
+    local exit_code=${PIPESTATUS[0]}
+    set -e
+    if [[ ${exit_code} -ne 0 ]]; then
+      echo "${tool} exited with status ${exit_code}" | tee -a "${log_file}"
+      STATUS=1
+    fi
+  else
+    echo "${tool} is not installed; skipping." | tee "${log_file}"
+  fi
+}
+
+run_tool "ruff" "ruff" "."
+run_tool "black" "black" "--check" "."
+run_tool "mypy" "mypy" "."
+run_tool "bandit" "bandit" "-r" "."
+run_tool "pip-audit" "pip-audit" "--progress-spinner" "off"
+run_tool "pytest" "pytest" "-vv"
+
+exit ${STATUS}


### PR DESCRIPTION
## Summary
- add a Python 3.12 Dockerfile configured for Django development and shared logging output
- provide a docker-compose stack with PostgreSQL, web, and tooling services mounting ./logs
- supply helper scripts, environment template, and gitignore rules for logs and dev artifacts

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e0e87868488324a6c3aa8e0e9b392d